### PR TITLE
Implement Apple Liquid Glass theme and chat improvements

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem "importmap-rails"
 gem "turbo-rails"
 # Hotwire's modest JavaScript framework [https://stimulus.hotwired.dev]
 gem "stimulus-rails"
+gem "tailwindcss-rails"
 # Build JSON APIs with ease [https://github.com/rails/jbuilder]
 gem "jbuilder"
 # Dotenv for environment variables [https://github.com/bkeepers/dotenv]

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/app/controllers/journeys_controller.rb
+++ b/app/controllers/journeys_controller.rb
@@ -27,38 +27,13 @@ class JourneysController < ApplicationController
 
   def chat
     @journey = Journey.find(session[:journey_id])
-    service = VisionChatService.new(journey: @journey)
-    result = service.call(prompt_text: params[:message])
+    user_message = @journey.conversation.messages.create!(role: 'user', content: params[:message])
 
-    if result.success?
-      user_message = @journey.conversation.messages.where(role: 'user').last
-      ai_response = @journey.conversation.messages.where(role: 'model').last
-    
-      # We will build an array of streams to render.
-      streams = []
-    
-      # Always append the chat messages.
-      streams << turbo_stream.append("chat_log", partial: "messages/message", locals: { message: user_message })
-      streams << turbo_stream.append("chat_log", partial: "messages/message", locals: { message: ai_response })
-    
-      # Conditionally add the profile card update if journey was updated.
-      if result.journey_updated?
-        # Reload the journey to get the latest data
-        @journey.reload
-        streams << turbo_stream.update("profile_card", partial: "journeys/profile_card", locals: { journey: @journey })
-      end
-    
-      respond_to do |format|
-        format.turbo_stream { render turbo_stream: streams }
-      end
-    else
-      # The error handling remains the same.
-      error_message = OpenStruct.new(role: 'Error', content: result.error)
-      respond_to do |format|
-        format.turbo_stream do
-          render turbo_stream: turbo_stream.append("chat_log", partial: "messages/message", locals: { message: error_message })
-        end
-      end
-    end
+    render turbo_stream: [
+      turbo_stream.append("chat_log", partial: "messages/message", locals: { message: user_message }),
+      turbo_stream.append("chat_log", partial: "messages/_typing_indicator")
+    ]
+
+    VisionChatJob.perform_later(@journey)
   end
 end

--- a/app/jobs/vision_chat_job.rb
+++ b/app/jobs/vision_chat_job.rb
@@ -1,0 +1,21 @@
+class VisionChatJob < ApplicationJob
+  queue_as :default
+
+  def perform(journey)
+    last_user_message = journey.conversation.messages.where(role: 'user').order(:created_at).last
+    return unless last_user_message
+
+    service = VisionChatService.new(journey: journey)
+    result = service.call(prompt_text: last_user_message.content)
+
+    if result.success?
+      ai_response = journey.conversation.messages.where(role: 'model').last
+      ai_response.broadcast_replace_to(
+        journey,
+        target: "typing_indicator",
+        partial: "messages/message",
+        locals: { message: ai_response }
+      )
+    end
+  end
+end

--- a/app/services/storyboard_creation_service.rb
+++ b/app/services/storyboard_creation_service.rb
@@ -1,62 +1,48 @@
-class StoryboardCreationService 
-    Result = Struct.new(:success?, :data, :error, keyword_init: true)
+class StoryboardCreationService
+  Result = Struct.new(:success?, :data, :error, keyword_init: true)
 
-    def initialize(journey:)
-        # Initialize the service with a journey object from which we can derive the conversation from the database.
-        @journey = journey
+  def initialize(journey:)
+    @journey = journey
+  end
+
+  def call
+    last_message = get_last_ai_message
+    return Result.new(success?: false, error: "No AI messages found.") unless last_message
+
+    json_data = extract_json_from_content(last_message.content)
+    return Result.new(success?: false, error: "Last AI message contains no valid JSON.") unless json_data
+
+    steps_array = json_data.dig('strategy', 'steps')
+    return Result.new(success?: false, error: "JSON is missing 'strategy.steps' array.") unless steps_array.is_a?(Array)
+
+    save_steps(steps_array)
+
+    Result.new(success?: true, data: @journey)
+  end
+
+  private
+
+  def get_last_ai_message
+    @journey.conversation&.messages&.where(role: 'model')&.order(:created_at)&.last
+  end
+
+  def extract_json_from_content(text_content)
+    match_data = text_content.match(/\{.*\}/m)
+    return nil unless match_data
+    JSON.parse(match_data[0])
+  rescue JSON::ParserError
+    nil
+  end
+
+  def save_steps(steps_data)
+    transformed_attributes = steps_data.map.with_index do |step_hash, index|
+      {
+        step_type: step_hash['type'],
+        channel: step_hash['channel'],
+        step_number: index + 1
+      }
     end
 
-    # get the output from the StrategicChatService and extract the json data and saving it to the steps table in the database.
-    def call
-        # 1. Find the last message in the conversation
-        last_message = get_last_ai_message
-        unless last_message
-            return Result.new(success?: false, error: "No AI message found in the conversation")
-        end
-
-        # 2. Extract the JSON string from the last message
-        json_data = extract_json_from_content(last_message.content)
-        unless json_data
-            return Result.new(success?: false, error: "No JSON data found in the last message")
-        end
-
-        #3. Parse the JSON and find the nested array of steps
-        steps_array = json_data.dig('strategy', 'steps')
-        unless steps_array.is_a?(Array)
-            return Result.new(success?: false, error: "json is missing the 'steps' array")
-        end 
-
-        #4. create the Step records in the database
-        save_steps(steps_array)
-        Result.new(success?:true, data: journey.reload.steps)
-    end
-
-    private
-    attr_reader :journey
-
-    def get_last_ai_message
-        # This method retrieves the last AI message from the conversation.
-        journey.conversation.messages.where(role: 'model')&.order(:created_at)&.last
-    end
-
-    def extract_json_from_content (text_content)
-        # The json might be surounded by other text so we will need regex to extract it.
-        match_data = text_content.match(/({.*})/m)
-        return nil unless match_data
-
-        json_string = match_data[0] # Extract the matched JSON string
-
-        JSON.parse(json_string)
-    rescue JSON::ParserError
-        nil # If parsing fails, return nil
-    end
-
-    def save_steps (steps_data)
-        #THe 'accepts_nested_attributes_for :steps' in the Journey model allows us to create steps directly through the journey.
-        journey.update!(steps_attributes: steps_data)
-    rescue ActiveRecord::RecordInvalid => e
-        # If saving the steps fails, return an error result.
-        raise e
-    end
+    @journey.update!(steps_attributes: transformed_attributes)
+  end
 end
-

--- a/app/views/journeys/_profile_card.html.erb
+++ b/app/views/journeys/_profile_card.html.erb
@@ -1,26 +1,21 @@
-<div id="profile_card">
-  <h3>Surprise Details</h3>
-  <p>
-    <strong>Recipient:</strong>
-    <%= journey.recipient_name.presence || "Not set" %>
-  </p>
-  <p>
-    <strong>Occasion:</strong>
-    <%= journey.occasion.presence || "Not set" %>
-  </p>
-  <p>
-    <strong>Interests:</strong>
-    <%= journey.interests.presence || "Not set" %>
-  </p>
-  <p>
-    <strong>Budget:</strong>
-    <%= journey.budget.presence || "Not set" %>
-  </p>
-  <p>
-    <strong>Tone:</strong>
-    <%= journey.tone.presence || "Not set" %>
-  </p>
-    <p>
-    <strong>Scheduled At:</strong>
-    <%= journey.scheduled_at.present? ? journey.scheduled_at.strftime("%B %d, %Y") : "Not set" %>
+<!-- Glass Panel for the profile card -->
+<div class="rounded-2xl border border-white/40 bg-white/20 p-6 shadow-lg backdrop-blur-xl">
+
+  <!-- Surprise Details Section -->
+  <h3 class="mb-4 border-b border-white/40 pb-2 text-lg font-bold text-gray-800">Surprise Details</h3>
+  <div class="space-y-3 text-sm">
+    <p><strong class="inline-block w-24 text-gray-500">Recipient:</strong> <span class="font-medium text-gray-900"><%= @journey.recipient_name.presence || "Not set" %></span></p>
+    <p><strong class="inline-block w-24 text-gray-500">Occasion:</strong> <span class="font-medium text-gray-900"><%= @journey.occasion.presence || "Not set" %></span></p>
+    <p><strong class="inline-block w-24 text-gray-500">Budget:</strong> <span class="font-medium text-gray-900"><%= @journey.budget.presence || "Not set" %></span></p>
+    <p><strong class="inline-block w-24 text-gray-500">Tone:</strong> <span class="font-medium text-gray-900"><%= @journey.tone.presence || "Not set" %></span></p>
+  </div>
+
+  <!-- Actions Section -->
+  <div class="mt-8">
+    <h3 class="mb-4 border-b border-white/40 pb-2 text-lg font-bold text-gray-800">Actions</h3>
+    <!-- This button is disabled for now. We will enable it later. -->
+    <button disabled class="w-full cursor-not-allowed rounded-lg bg-gray-300 px-4 py-3 font-bold text-gray-500">
+      Generate Strategy
+    </button>
+  </div>
 </div>

--- a/app/views/journeys/new.html.erb
+++ b/app/views/journeys/new.html.erb
@@ -1,37 +1,40 @@
-<h1>Let's Design Your Surprise!</h1>
+<!-- Main responsive container: stacks vertically on mobile, becomes a row on medium screens -->
+<div class="flex flex-col gap-8 md:flex-row animate-fade-in-up">
 
-<div style="display: flex; gap: 2rem;">
+  <!-- Left Column: Chat Interface -->
+  <div class="w-full md:w-2/3">
+    <!-- Glass Panel for the chat -->
+    <div class="flex h-[75vh] flex-col rounded-2xl border border-white/40 bg-white/20 shadow-lg backdrop-blur-xl">
 
-  <%# Left Side: The Chat Interface %>
-  <div style="flex: 2;">
-    <div id="chat_log">
-      <div class="message">
-        <strong>Surprizen Bot:</strong> Hello! Ready to plan an awesome Surprizen Journey?
+      <!-- Chat Log Container -->
+      <%= turbo_stream_from @journey do %>
+        <div id="chat_log" class="flex-grow space-y-4 overflow-y-auto p-6 pr-4">
+          <!-- Messages will be appended here by Turbo Streams -->
+          <div class="flex">
+            <div class="max-w-md rounded-lg rounded-bl-none bg-gray-200/50 p-3">
+              <p class="text-sm text-gray-700">Hello! I'm your friendly gift concierge. Tell me a bit about the surprise you're planning.</p>
+            </div>
+          </div>
+        </div>
+      <% end %>
+
+      <!-- Input Form -->
+      <div class="border-t border-white/30 p-6">
+        <%= form_with url: chat_journeys_path, method: :post, class: "space-y-4" do |form| %>
+          <div>
+            <%= form.label :message, "Your Message", class: "text-sm font-medium text-gray-600" %>
+            <%= form.text_field :message, autocomplete: "off", placeholder: "Type your message here...", class: "mt-1 w-full rounded-lg border border-gray-300/50 bg-white/40 p-3 transition focus:outline-none focus:ring-2 focus:ring-blue-500" %>
+          </div>
+          <%= form.submit "Send", class: "w-full cursor-pointer rounded-lg bg-blue-600 px-4 py-3 font-bold text-white shadow-md transition hover:scale-105 active:scale-95 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-opacity-50" %>
+        <% end %>
       </div>
     </div>
-    <hr>
-
-    <%# THIS IS THE MISSING LINE THAT NEEDS TO BE ADDED %>
-    <%= form_with url: chat_journeys_path, method: :post do |form| %>
-
-      <div class="field">
-        <%= form.label :message %>
-        <%= form.text_field :message, autocomplete: "off" %>
-      </div>
-
-      <div class="actions">
-        <%= form.submit "Send" %>
-      </div>
-      
-    <%# This 'end' tag was causing the error because its opening tag was missing %>
-    <% end %>
   </div>
 
-  <%# Right Side: The Live-Updating Profile Card %>
-  <div style="flex: 1;">
+  <!-- Right Column: Sidebar -->
+  <div class="w-full md:w-1/3">
     <%= turbo_frame_tag "profile_card" do %>
       <%= render "journeys/profile_card", journey: @journey %>
     <% end %>
   </div>
-
 </div>

--- a/app/views/journeys/show.html.erb
+++ b/app/views/journeys/show.html.erb
@@ -1,15 +1,15 @@
-<!-- This is the main container for your storyboard page -->
-<div>
-  <h2 class="text-3xl font-bold">Your Storyboard: <%= @journey.title %></h2>
-  <p class="text-gray-600">Review the steps for your surprise journey below.</p>
+<!-- Main Glass Panel for the storyboard, with fade-in animation -->
+<div class="animate-fade-in-up rounded-2xl border border-white/40 bg-white/20 p-6 shadow-lg backdrop-blur-xl md:p-8">
+  <h2 class="mb-2 text-3xl font-bold text-gray-900">Your Storyboard: <%= @journey.title %></h2>
+  <p class="mb-8 text-gray-600">Review the steps for your surprise journey below. This is the plan that will be launched for your recipient.</p>
 
-  <div class="mt-6 space-y-4">
-    <%# This line will render the _step.html.erb partial for each step %>
+  <div class="space-y-6">
+    <!-- Render the collection of steps using a partial. Rails will loop through them automatically. -->
     <%= render @journey.steps.order(:step_number) %>
   </div>
 
-  <div class="mt-8">
-    <a href="#" class="bg-green-600 text-white font-bold py-3 px-4 rounded-lg">
+  <div class="mt-10 border-t border-white/40 pt-6">
+    <a href="#" class="block w-full rounded-lg bg-green-600 px-4 py-3 text-center font-bold text-white shadow-md transition hover:scale-105 hover:bg-green-700 active:scale-95">
       Proceed to Payment
     </a>
   </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,28 +1,41 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title><%= content_for(:title) || "Surprizen" %></title>
+    <title>Surprizen</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
-    <meta name="apple-mobile-web-app-capable" content="yes">
-    <meta name="mobile-web-app-capable" content="yes">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
-
-    <%= yield :head %>
-
-    <%# Enable PWA manifest for installable apps (make sure to enable in config/routes.rb too!) %>
-    <%#= tag.link rel: "manifest", href: pwa_manifest_path(format: :json) %>
-
-    <link rel="icon" href="/icon.png" type="image/png">
-    <link rel="icon" href="/icon.svg" type="image/svg+xml">
-    <link rel="apple-touch-icon" href="/icon.png">
-
-    <%# Includes all stylesheet files in app/assets/stylesheets %>
-    <%= stylesheet_link_tag :app, "data-turbo-track": "reload" %>
+    <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
   </head>
 
-  <body>
-    <%= yield %>
+  <body class="bg-gray-50 font-sans text-gray-800 antialiased">
+    <!-- Background Gradient -->
+    <div class="absolute top-0 left-0 -z-10 h-full w-full bg-gradient-to-br from-gray-100 via-white to-blue-50"></div>
+
+    <!-- Main Container -->
+    <main class="container mx-auto p-4 sm:p-6 lg:p-8">
+      <!-- Header -->
+      <header class="flex items-center justify-between border-b border-gray-200/80 pb-4 animate-fade-in-down">
+        <h1 class="text-2xl font-bold text-gray-900">Surprizen</h1>
+        <div class="text-sm text-gray-500">Logged in as: <span class="font-medium text-gray-700">Tobias</span></div>
+      </header>
+
+      <!-- Progress Stepper -->
+      <nav class="my-8 flex items-center justify-center space-x-2 sm:space-x-4 animate-fade-in-down">
+        <div class="flex items-center rounded-full bg-blue-600 px-4 py-2 text-sm text-white shadow-lg sm:text-base">
+          <span>1. Vision</span>
+        </div>
+        <div class="text-gray-300">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clip-rule="evenodd" /></svg>
+        </div>
+        <div class="flex items-center text-sm text-gray-500 sm:text-base">
+          <span>2. Strategy</span>
+        </div>
+      </nav>
+
+      <!-- Responsive Content Area -->
+      <%= yield %>
+    </main>
   </body>
 </html>

--- a/app/views/messages/_message.html.erb
+++ b/app/views/messages/_message.html.erb
@@ -1,3 +1,15 @@
-<div class="message">
-  <strong><%= message.role.humanize %>:</strong> <%= message.content %>
-</div>
+<% if message.role == 'user' %>
+  <!-- User Message -->
+  <div class="flex justify-end">
+    <div class="max-w-md rounded-lg rounded-br-none bg-blue-600 p-3 text-white">
+      <p class="text-sm"><%= message.content %></p>
+    </div>
+  </div>
+<% else %>
+  <!-- Bot/Error Message -->
+  <div class="flex">
+    <div class="max-w-md rounded-lg rounded-bl-none bg-gray-200/50 p-3">
+      <p class="text-sm text-gray-700"><%= message.content %></p>
+    </div>
+  </div>
+<% end %>

--- a/app/views/messages/_typing_indicator.html.erb
+++ b/app/views/messages/_typing_indicator.html.erb
@@ -1,0 +1,7 @@
+<div id="typing_indicator" class="flex">
+  <div class="flex items-center space-x-1 rounded-lg rounded-bl-none bg-gray-200/50 p-3">
+    <span class="h-2 w-2 animate-pulse rounded-full bg-gray-400" style="animation-delay: 0s;"></span>
+    <span class="h-2 w-2 animate-pulse rounded-full bg-gray-400" style="animation-delay: 0.2s;"></span>
+    <span class="h-2 w-2 animate-pulse rounded-full bg-gray-400" style="animation-delay: 0.4s;"></span>
+  </div>
+</div>

--- a/app/views/steps/_step.html.erb
+++ b/app/views/steps/_step.html.erb
@@ -1,5 +1,7 @@
-<!-- This template defines how one single step is displayed -->
-<div class="p-4 bg-gray-100 rounded-lg">
-  <h4 class="font-bold">Step <%= step.step_number %>: <%= step.puzzle_type.humanize %></h4>
-  <p class="mt-2">Clue: <%= step.clue || "To be generated." %></p>
+<%# This partial renders a single step. The 'step' variable is provided by Rails. %>
+<%# We add a staggered animation delay based on the step's position in the list. %>
+<div class="animate-fade-in-up rounded-lg border border-white/50 bg-white/30 p-4" style="animation-delay: <%= step_counter * 100 %>ms;">
+  <h4 class="font-bold text-gray-800">Step <%= step.step_number %>: <%= step.step_type.humanize %></h4>
+  <p class="text-sm text-gray-600">Channel: <%= step.channel %></p>
+  <p class="mt-2 text-gray-700">Clue: <%= step.clue || "To be generated." %></p>
 </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,20 @@
+module.exports = {
+  theme: {
+    extend: {
+      keyframes: {
+        'fade-in-down': {
+          '0%': { opacity: '0', transform: 'translateY(-10px)' },
+          '100%': { opacity: '1', transform: 'translateY(0)' },
+        },
+        'fade-in-up': {
+          '0%': { opacity: '0', transform: 'translateY(10px) scale(0.98)' },
+          '100%': { opacity: '1', transform: 'translateY(0) scale(1)' },
+        }
+      },
+      animation: {
+        'fade-in-down': 'fade-in-down 0.5s ease-out',
+        'fade-in-up': 'fade-in-up 0.6s ease-out forwards',
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add `tailwindcss-rails` gem
- configure Tailwind and custom animations
- restyle layout, chat view, and profile card
- update storyboard and step views
- implement `VisionChatJob` for async AI responses with typing indicator
- refactor `StoryboardCreationService`

## Testing
- `RBENV_VERSION=3.2.3 bin/rails test` *(fails: Could not find gem 'tailwindcss-rails')*

------
https://chatgpt.com/codex/tasks/task_e_686f671337608320b85d6e8f00419a5d